### PR TITLE
Handling errors that come from obspy not being able to read quakeml f…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,10 +66,10 @@ jobs:
         imageName: 'macOS-10.14'
         python.version: '3.6'
       MacOS_10_14_Python37:
-        imageName: 'macOS-10.15'
-        python.version: '3.7'
-      MacOS_10_14_Python36:
         imageName: 'macOS-10.14'
+        python.version: '3.7'
+      MacOS_10_15_Python36:
+        imageName: 'macOS-10.15'
         python.version: '3.6'
       MacOS_10_15_Python37:
         imageName: 'macOS-10.15'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,17 +62,17 @@ jobs:
       Linux_Python37:
         imageName: 'ubuntu-latest'
         python.version: '3.7'
-      MacOS_10_13_Python36:
-        imageName: 'macOS-10.13'
-        python.version: '3.6'
-      MacOS_10_13_Python37:
-        imageName: 'macOS-10.13'
-        python.version: '3.7'
       MacOS_10_14_Python36:
         imageName: 'macOS-10.14'
         python.version: '3.6'
       MacOS_10_14_Python37:
+        imageName: 'macOS-10.15'
+        python.version: '3.7'
+      MacOS_10_14_Python36:
         imageName: 'macOS-10.14'
+        python.version: '3.6'
+      MacOS_10_15_Python37:
+        imageName: 'macOS-10.15'
         python.version: '3.7'
   pool:
     vmImage: $(imageName)

--- a/libcomcat/classes.py
+++ b/libcomcat/classes.py
@@ -659,7 +659,14 @@ class DetailEvent(object):
                 if product == 'origin' and phase_data.source == 'us':
                     continue
                 phase_url = phase_data.getContentURL('quakeml.xml')
-                catalog = read_events(phase_url)
+                try:
+                    catalog = read_events(phase_url)
+                except Exception as e:
+                    fmt = ('Could not parse quakeml file from %s. '
+                           'Error: %s')
+                    tpl = (phase_url, str(e))
+                    logging.warning(fmt % tpl)
+                    continue
                 event = catalog.events[0]
                 for magnitude in event.magnitudes:
                     edict['magnitude%i' % imag] = magnitude.mag


### PR DESCRIPTION
…iles - likely those that contain values not matching spec. These errors are now logged as warnings.